### PR TITLE
Fix wso2-extensions/identity-oauth2-grant-jwt#26: IAT validation in JWT

### DIFF
--- a/component/grant-type/pom.xml
+++ b/component/grant-type/pom.xml
@@ -15,17 +15,19 @@
  ~ limitations under the License.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>org.wso2.carbon.identity.oauth2.grant.jwt</artifactId>
-    <packaging>bundle</packaging>
-    <name>JWT grant type for OAuth2</name>
-    <url>http://wso2.org</url>
+
     <parent>
         <groupId>org.wso2.carbon.extension.identity.oauth2.grantType.jwt</groupId>
         <artifactId>identity-inbound-oauth2-grant-jwt</artifactId>
         <version>1.0.16-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.carbon.identity.oauth2.grant.jwt</artifactId>
+    <packaging>bundle</packaging>
+    <name>JWT grant type for OAuth2</name>
+    <url>http://wso2.org</url>
 
     <dependencies>
         <dependency>
@@ -54,27 +56,24 @@
             <artifactId>org.wso2.carbon.identity.testutil</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.eclipse.osgi</groupId>
+            <artifactId>org.eclipse.osgi.services</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.felix</groupId>
-                    <artifactId>maven-bundle-plugin</artifactId>
-                    <version>2.3.5</version>
-                    <extensions>true</extensions>
-                </plugin>
-            </plugins>
-        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.0</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>
@@ -124,7 +123,6 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-scr-plugin</artifactId>
-                <version>1.7.2</version>
                 <executions>
                     <execution>
                         <id>generate-scr-scrdescriptor</id>

--- a/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTConstants.java
+++ b/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTConstants.java
@@ -21,11 +21,13 @@ public class JWTConstants {
 
     public static final String OAUTH_JWT_BEARER_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:jwt-bearer";
     public static final String OAUTH_JWT_ASSERTION = "assertion";
-    public static final String VALIDITY_PERIOD = "validityPeriod";
-    public static final String CACHE_USED_JTI = "cacheUsed";
-    public static final String PROPERTIES_FILE = "jwt.properties";
     public static final String JWKS_URI = "jwksUri";
     public static final String JWKS_VALIDATION_ENABLE_CONFIG = "JWTValidatorConfigs.Enable";
     // Expiry time of the jwt token
     public static final String EXPIRY_TIME = "EXPIRY_TIME_JWT";
+
+    public static final String PROP_ENABLE_IAT_VALIDATION = "OAuth.JWTGrant.EnableIATValidation";
+    public static final String PROP_IAT_VALIDITY_PERIOD = "OAuth.JWTGrant.IATValidityPeriod";
+    public static final String PROP_ENABLE_JWT_CACHE = "OAuth.JWTGrant.EnableJWTCache";
+    public static final int DEFAULT_IAT_VALIDITY_PERIOD = 30;
 }

--- a/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/internal/JWTServiceComponent.java
+++ b/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/internal/JWTServiceComponent.java
@@ -20,11 +20,18 @@ package org.wso2.carbon.identity.oauth2.grant.jwt.internal;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent;
 
-/**
- * @scr.component name="identity.oauth2.grant.jwt.component" immediate="true"
- */
+@Component(
+        name = "identity.oauth2.grant.jwt.component",
+        immediate = true
+)
 public class JWTServiceComponent {
+
     private static Log log = LogFactory.getLog(JWTServiceComponent.class);
 
     protected void activate(ComponentContext ctxt) {
@@ -37,5 +44,25 @@ public class JWTServiceComponent {
         if (log.isDebugEnabled()) {
             log.debug("JWT grant handler is deactivated");
         }
+    }
+
+    @Reference(
+            name = "identityCoreInitializedEventService",
+            service = org.wso2.carbon.identity.core.util.IdentityCoreInitializedEvent.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetIdentityCoreInitializedEventService"
+    )
+    protected void setIdentityCoreInitializedEventService(IdentityCoreInitializedEvent identityCoreInitializedEvent) {
+
+        /* reference IdentityCoreInitializedEvent service to guarantee that this component will wait until identity core
+         is activated. As we use IdentityUtils for reading JWT grant related properties, we should making sure identity
+         core is activated. */
+    }
+
+    protected void unsetIdentityCoreInitializedEventService(IdentityCoreInitializedEvent identityCoreInitializedEvent) {
+
+        /*  IdentityCoreInitializedEvent un-registration is ignored as we do not keep a reference during
+        initialization. */
     }
 }

--- a/component/grant-type/src/main/resources/jwt.properties
+++ b/component/grant-type/src/main/resources/jwt.properties
@@ -1,5 +1,0 @@
-#Time period to reject the token which is issued before the allowed time.
-validityPeriod=30
-
-#Whether cache used to store the jWT
-cacheUsed=true123

--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,16 @@
                 <scope>test</scope>
                 <version>${org.wso2.carbon.identity.testutil.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.wso2.eclipse.osgi</groupId>
+                <artifactId>org.eclipse.osgi.services</artifactId>
+                <version>${equinox.osgi.services.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
+                <version>${apache.felix.scr.ds.annotations.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -280,11 +290,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.1</version>
+                <version>3.7.0</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>
@@ -293,7 +303,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-scr-plugin</artifactId>
-                    <version>1.7.2</version>
+                    <version>1.22.0</version>
                     <executions>
                         <execution>
                             <id>generate-scr-scrdescriptor</id>
@@ -306,7 +316,7 @@
                 <plugin>
                     <groupId>org.apache.felix</groupId>
                     <artifactId>maven-bundle-plugin</artifactId>
-                    <version>2.3.5</version>
+                    <version>2.4.0</version>
                     <extensions>true</extensions>
                     <configuration>
                         <obrRepository>NONE</obrRepository>
@@ -444,6 +454,8 @@
         <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>
         <commons-lang.wso2.osgi.version.range>[2.6.0,3.0.0)</commons-lang.wso2.osgi.version.range>
         <net.minidev.json.imp.pkg.version.range>[1.3.0, 2.0.0)</net.minidev.json.imp.pkg.version.range>
+        <apache.felix.scr.ds.annotations.version>1.2.4</apache.felix.scr.ds.annotations.version>
+        <equinox.osgi.services.version>3.5.100.v20160504-1419</equinox.osgi.services.version>
 
         <!-- testing dependencies-->
         <testng.version>6.9.10</testng.version>


### PR DESCRIPTION
- Change to jdk 1.8
- Change to new scr annotations
- Remove jwt.properties file

### Proposed changes in this pull request

## Purpose

Configs in `jwt.properties` are moved to `identity.xml`. The below configs are added to identity.xml under <OAuth> tag 

```xml
        <JWTGrant>
            
            <!-- Validate issued at time (iat) of JWT token. The validity can be set using 'IATValidity' configuration. -->
            <EnableIATValidation>false</EnableIATValidation>
            <!-- Reject the JWT if the iat of JWT is pass a certain time period. Time period is in minutes.
             'EnableIATValidation' configuration should be set to 'true' in order to make use of the validity period.
             -->
            <IATValidityPeriod>100</IATValidityPeriod>
            <!-- Store JWT in a cache against the JTI of the token -->
            <EnableJWTCache>true</EnableJWTCache>
        </JWTGrant>

```