### PR TITLE
JWTBearerGrantHandler fails to add federated IDP name when setting authorized user to token request message context

### DIFF
--- a/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTBearerGrantHandler.java
+++ b/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTBearerGrantHandler.java
@@ -460,6 +460,7 @@ public class JWTBearerGrantHandler extends AbstractAuthorizationGrantHandler {
                     .createLocalAuthenticatedUserFromSubjectIdentifier(authenticatedSubjectIdentifier);
         }
         authenticatedUser.setFederatedUser(true);
+        authenticatedUser.setFederatedIdPName(identityProvider.getIdentityProviderName());
         tokenReqMsgCtx.setAuthorizedUser(authenticatedUser);
     }
 


### PR DESCRIPTION
Part of fix for wso2/product-is#4879
Depends on the OAuth fix.