### PR TITLE
Fix avoid persisting standard claims in the claim cache

### DIFF
--- a/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTBearerGrantHandler.java
+++ b/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTBearerGrantHandler.java
@@ -521,13 +521,13 @@ public class JWTBearerGrantHandler extends AbstractAuthorizationGrantHandler {
         Map<String, String> customClaimMap = new HashMap<>();
         for (Map.Entry<String, Object> entry : customClaims.entrySet()) {
             String entryKey = entry.getKey();
-            boolean isNotRegisteredClaim = true;
+            boolean isRegisteredClaim = false;
             for (int registeredClaim = 0; registeredClaim < registeredClaimNames.length; registeredClaim++) {
                 if (registeredClaimNames[registeredClaim].equals((entryKey))) {
-                    isNotRegisteredClaim = false;
+                    isRegisteredClaim = true;
                 }
             }
-            if (isNotRegisteredClaim) {
+            if (!isRegisteredClaim) {
                 Object value = entry.getValue();
                 customClaimMap.put(entryKey, value.toString());
             }

--- a/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTBearerGrantHandler.java
+++ b/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTBearerGrantHandler.java
@@ -77,6 +77,7 @@ import static org.wso2.carbon.identity.oauth2.grant.jwt.JWTConstants.DEFAULT_IAT
 import static org.wso2.carbon.identity.oauth2.grant.jwt.JWTConstants.PROP_ENABLE_IAT_VALIDATION;
 import static org.wso2.carbon.identity.oauth2.grant.jwt.JWTConstants.PROP_ENABLE_JWT_CACHE;
 import static org.wso2.carbon.identity.oauth2.grant.jwt.JWTConstants.PROP_IAT_VALIDITY_PERIOD;
+import static org.wso2.carbon.identity.oauth2.grant.jwt.JWTConstants.PROP_REGISTERED_JWT;
 
 /**
  * Class to handle JSON Web Token(JWT) grant type
@@ -90,6 +91,7 @@ public class JWTBearerGrantHandler extends AbstractAuthorizationGrantHandler {
     private static final String ERROR_GET_RESIDENT_IDP =
             "Error while getting Resident Identity Provider of '%s' tenant.";
     private static Map<Integer, Key> privateKeys = new ConcurrentHashMap<>();
+    private String[] registeredClaimNames = new String[] { "iss", "sub", "aud", "exp", "nbf", "iat", "jti" };
 
     private String tenantDomain;
     private int validityPeriod;
@@ -140,6 +142,10 @@ public class JWTBearerGrantHandler extends AbstractAuthorizationGrantHandler {
                 log.warn("Empty value is set for IAT validity period. Using default value: " + validityPeriod
                         + " minutes.");
             }
+        }
+        String registeredClaims = IdentityUtil.getProperty(PROP_REGISTERED_JWT);
+        if (StringUtils.isNotBlank(registeredClaims)) {
+            registeredClaimNames = registeredClaims.split("\\s*,\\s*");
         }
 
         String cacheJWTProp = IdentityUtil.getProperty(PROP_ENABLE_JWT_CACHE);
@@ -514,8 +520,17 @@ public class JWTBearerGrantHandler extends AbstractAuthorizationGrantHandler {
 
         Map<String, String> customClaimMap = new HashMap<>();
         for (Map.Entry<String, Object> entry : customClaims.entrySet()) {
-            Object value = entry.getValue();
-            customClaimMap.put(entry.getKey(), value.toString());
+            String entryKey = entry.getKey();
+            boolean isNotRegisteredClaim = true;
+            for (int registeredClaim = 0; registeredClaim < registeredClaimNames.length; registeredClaim++) {
+                if (registeredClaimNames[registeredClaim].equals((entryKey))) {
+                    isNotRegisteredClaim = false;
+                }
+            }
+            if (isNotRegisteredClaim) {
+                Object value = entry.getValue();
+                customClaimMap.put(entryKey, value.toString());
+            }
         }
         return customClaimMap;
     }

--- a/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTConstants.java
+++ b/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTConstants.java
@@ -30,4 +30,5 @@ public class JWTConstants {
     public static final String PROP_IAT_VALIDITY_PERIOD = "OAuth.JWTGrant.IATValidityPeriod";
     public static final String PROP_ENABLE_JWT_CACHE = "OAuth.JWTGrant.EnableJWTCache";
     public static final int DEFAULT_IAT_VALIDITY_PERIOD = 30;
+    public static final String PROP_REGISTERED_JWT = "OAuth.JWTGrant.RegisteredClaim";
 }

--- a/component/grant-type/src/test/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTBearerGrantHandlerTest.java
+++ b/component/grant-type/src/test/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTBearerGrantHandlerTest.java
@@ -32,7 +32,9 @@ import org.wso2.carbon.identity.application.authentication.framework.model.Authe
 import org.wso2.carbon.identity.application.common.IdentityApplicationManagementException;
 import org.wso2.carbon.identity.application.common.model.IdentityProvider;
 import org.wso2.carbon.identity.base.IdentityException;
+import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth2.token.OAuthTokenReqMessageContext;
+import org.wso2.carbon.identity.oauth2.token.OauthTokenIssuer;
 import org.wso2.carbon.identity.oauth2.util.ClaimsUtil;
 
 import java.util.ArrayList;
@@ -44,7 +46,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 /**
  * This is a test class for {@link JWTBearerGrantHandler}.
  */
-@PrepareForTest({ClaimsUtil.class})
+@PrepareForTest({ ClaimsUtil.class, OAuthServerConfiguration.class })
 public class JWTBearerGrantHandlerTest {
 
     @ObjectFactory
@@ -57,8 +59,12 @@ public class JWTBearerGrantHandlerTest {
             dataProvider = "customClaimDataProvider", dependsOnMethods = "testHandleCustomClaims")
     public void testCustomClaims(Map<String, Object> customClaims) {
 
-        JWTBearerGrantHandler jwtBearerGrantHandler = Mockito.mock(JWTBearerGrantHandler.class);
-        Mockito.doCallRealMethod().when(jwtBearerGrantHandler).getCustomClaims(Mockito.anyMap());
+        PowerMockito.mockStatic(OAuthServerConfiguration.class);
+        OAuthServerConfiguration mockOauthServerConfig = Mockito.mock(OAuthServerConfiguration.class);
+        OauthTokenIssuer identityOauthTokenIssuer = Mockito.mock(OauthTokenIssuer.class);
+        when(OAuthServerConfiguration.getInstance()).thenReturn(mockOauthServerConfig);
+        when(mockOauthServerConfig.getIdentityOauthTokenIssuer()).thenReturn(identityOauthTokenIssuer);
+        JWTBearerGrantHandler jwtBearerGrantHandler = new JWTBearerGrantHandler();
         Map<String, String> customClaimsMap = jwtBearerGrantHandler.getCustomClaims(customClaims);
 
         for (Map.Entry<String, Object> entry : customClaims.entrySet()) {
@@ -81,11 +87,12 @@ public class JWTBearerGrantHandlerTest {
             }
         });
 
-        JWTBearerGrantHandler jwtBearerGrantHandler = Mockito.mock(JWTBearerGrantHandler.class);
-        Mockito.doCallRealMethod().when(jwtBearerGrantHandler)
-                .handleCustomClaims(Mockito.any(OAuthTokenReqMessageContext.class), Mockito.anyMap(),
-                        Mockito.any(IdentityProvider.class));
-        Mockito.doCallRealMethod().when(jwtBearerGrantHandler).getCustomClaims(Mockito.anyMap());
+        PowerMockito.mockStatic(OAuthServerConfiguration.class);
+        OAuthServerConfiguration mockOauthServerConfig = Mockito.mock(OAuthServerConfiguration.class);
+        OauthTokenIssuer identityOauthTokenIssuer = Mockito.mock(OauthTokenIssuer.class);
+        when(OAuthServerConfiguration.getInstance()).thenReturn(mockOauthServerConfig);
+        when(mockOauthServerConfig.getIdentityOauthTokenIssuer()).thenReturn(identityOauthTokenIssuer);
+        JWTBearerGrantHandler jwtBearerGrantHandler = new JWTBearerGrantHandler();
 
         OAuthTokenReqMessageContext oAuthTokenReqMessageContext = Mockito.mock(OAuthTokenReqMessageContext.class);
         IdentityProvider identityProvider = new IdentityProvider();


### PR DESCRIPTION
### Proposed changes in this pull request

When We try to get the custom claims, I have noticed in the JWT grant handler is persisting each and every claim rather than considering whether it's a custom claim or not. Due to this reason, The backend JWT generator is throwing exceptions when populating the claims.

To avoid this problem, We can change the JWT Bearer grant handler to persist only the custom claims.
For that, I get all standard registered claims [1] and check with the claim list and only allows the custom claims. 
Addition to that, if we want we can also configure default claims in identity.xml.

[2] https://static.javadoc.io/com.nimbusds/nimbus-jose-jwt/5.4/com/nimbusds/jwt/JWTClaimsSet.html

issue: wso2/product-is#5872