### PR TITLE
Introduce a config to disable refresh tokens for jwt-bearer grant

### DIFF
--- a/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTBearerGrantHandler.java
+++ b/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTBearerGrantHandler.java
@@ -51,6 +51,7 @@ import org.wso2.carbon.identity.application.common.util.IdentityApplicationManag
 import org.wso2.carbon.identity.base.IdentityException;
 import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
+import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
 import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
 import org.wso2.carbon.identity.oauth2.dto.OAuth2AccessTokenRespDTO;
@@ -516,6 +517,13 @@ public class JWTBearerGrantHandler extends AbstractAuthorizationGrantHandler {
             ClaimsUtil.addUserAttributesToCache(tokenRespDTO, tokReqMsgCtx, userAttributes);
         }
         return tokenRespDTO;
+    }
+
+    @Override
+    public boolean issueRefreshToken() throws IdentityOAuth2Exception {
+
+        return OAuthServerConfiguration.getInstance()
+                .getValueForIsRefreshTokenAllowed(OAuthConstants.GrantTypes.JWT_BEARER);
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -405,8 +405,8 @@
         </snapshotRepository>
     </distributionManagement>
     <properties>
-        <carbon.identity.framework.version>5.12.387</carbon.identity.framework.version>
-        <carbon.identity.oauth.version>6.0.10</carbon.identity.oauth.version>
+        <carbon.identity.framework.version>5.18.59</carbon.identity.framework.version>
+        <carbon.identity.oauth.version>6.4.53</carbon.identity.oauth.version>
         <commons-logging.version>4.4.3</commons-logging.version>
         <carbon.kernel.version>4.4.3</carbon.kernel.version>
         <org.apache.oltu.oauth2.client.version>1.0.0</org.apache.oltu.oauth2.client.version>


### PR DESCRIPTION
### Proposed changes in this pull request

- Resolves https://github.com/wso2/product-is/issues/9176

- Add the below config to the `deployment.toml` to disable the refresh token for JWT bearer grant type.
```
[oauth.grant_type.jwt_bearer]
allow_refresh_tokens = false
```

- Depends on https://github.com/wso2-extensions/identity-inbound-auth-oauth/pull/1428, https://github.com/wso2/carbon-identity-framework/pull/3069