### PR TITLE
Update Dependencies to IPK versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -361,8 +361,8 @@
         </snapshotRepository>
     </distributionManagement>
     <properties>
-        <carbon.identity.framework.version>5.20.66</carbon.identity.framework.version>
-        <carbon.identity.oauth.version>6.4.80</carbon.identity.oauth.version>
+        <carbon.identity.framework.version>6.0.0</carbon.identity.framework.version>
+        <carbon.identity.oauth.version>7.0.0</carbon.identity.oauth.version>
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
         <org.apache.oltu.oauth2.client.version>0.31</org.apache.oltu.oauth2.client.version>
         <org.apache.oltu.oauth2.common.version>1.0.1</org.apache.oltu.oauth2.common.version>
@@ -378,8 +378,8 @@
         <encoder.wso2.version>1.2.0.wso2v1</encoder.wso2.version>
         <nimbusds.version>7.3.0.wso2v1</nimbusds.version>
         <oltu.version>1.0.0.wso2v3</oltu.version>
-        <carbon.identity.package.import.version.range>[5.0.0, 6.0.0)</carbon.identity.package.import.version.range>
-        <carbon.identity.oauth.package.import.version.range>[6.0.0, 7.0.0)</carbon.identity.oauth.package.import.version.range>
+        <carbon.identity.package.import.version.range>[6.0.0, 7.0.0)</carbon.identity.package.import.version.range>
+        <carbon.identity.oauth.package.import.version.range>[7.0.0, 8.0.0)</carbon.identity.oauth.package.import.version.range>
         <carbon.kernel.package.import.version.range>[4.4.0, 5.0.0)</carbon.kernel.package.import.version.range>
         <nimbusds.osgi.version.range>[7.3.0,8.0.0)</nimbusds.osgi.version.range>
         <commons-logging.osgi.version.range>[1.2,2.0)</commons-logging.osgi.version.range>


### PR DESCRIPTION
The identity components are bumped to major versions created for IPK.

Related issue: https://github.com/wso2-enterprise/identity-k8s-access-runtime/issues/16