### PR TITLE
Check the activeness of idp after resident idp case is handled

### DIFF
--- a/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTBearerGrantHandler.java
+++ b/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTBearerGrantHandler.java
@@ -328,9 +328,6 @@ public class JWTBearerGrantHandler extends AbstractAuthorizationGrantHandler {
                 identityProvider = IdentityProviderManager.getInstance().getIdPByName(jwtIssuer, tenantDomain);
             }
             if (identityProvider != null) {
-                if (!identityProvider.isEnable()) {
-                    handleException("No Active IDP found for the JWT with issuer name : " + jwtIssuer);
-                }
                 // if no IDPs were found for a given name, the IdentityProviderManager returns a dummy IDP with the
                 // name "default". We need to handle this case.
                 if (StringUtils.equalsIgnoreCase(identityProvider.getIdentityProviderName(), DEFAULT_IDP_NAME)) {
@@ -341,6 +338,9 @@ public class JWTBearerGrantHandler extends AbstractAuthorizationGrantHandler {
                     }
                 }
 
+                if (!identityProvider.isEnable()) {
+                    handleException("No Active IDP found for the JWT with issuer name : " + jwtIssuer);
+                }
                 tokenEndPointAlias = getTokenEndpointAlias(identityProvider);
             } else {
                 handleClientException("No registered identity provider found for the JWT with issuer name : " + jwtIssuer);


### PR DESCRIPTION
### Purpose

> As the IdentityProviderManager returns a dummy IDP with the name "default" it always returns IDP status as disabled. The resident IDP as the token issuer case is getting hit by after this point only. We need to check whether the issuer is from a federated idp or resident idp and then only the finalized idp should be tested for activeness.
