### PR TITLE
Add custom keystore support to JWT bearer grant

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -26,7 +26,7 @@ jobs:
           distribution: "adopt"
       - name: Cache local Maven repository
         id: cache-maven-m2
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-m2
         with:

--- a/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTBearerGrantHandler.java
+++ b/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTBearerGrantHandler.java
@@ -927,7 +927,20 @@ public class JWTBearerGrantHandler extends AbstractAuthorizationGrantHandler {
     protected X509Certificate resolveSignerCertificate(JWSHeader header,
                                                        IdentityProvider idp) throws IdentityOAuth2Exception {
 
-        return OAuth2Util.resolverSignerCertificate(idp);
+        X509Certificate x509Certificate = null;
+        try {
+            if (StringUtils.equals(IdentityApplicationConstants.RESIDENT_IDP_RESERVED_NAME,
+                    idp.getIdentityProviderName())) {
+                x509Certificate = (X509Certificate) OAuth2Util.getCertificate(tenantDomain);
+            } else {
+                x509Certificate =
+                        (X509Certificate) IdentityApplicationManagementUtil.decodeCertificate(idp.getCertificate());
+            }
+        } catch (CertificateException e) {
+            handleException("Error occurred while decoding public certificate of Identity Provider "
+                    + idp.getIdentityProviderName() + " for tenant domain " + tenantDomain);
+        }
+        return x509Certificate;
     }
 
     /**

--- a/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTBearerGrantHandler.java
+++ b/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTBearerGrantHandler.java
@@ -1009,7 +1009,7 @@ public class JWTBearerGrantHandler extends AbstractAuthorizationGrantHandler {
     private boolean isEncryptedJWTSigned(String payload) {
 
         if (StringUtils.isNotEmpty(payload)) {
-            String[] parts = payload.split(".");
+            String[] parts = payload.split("\\.");
             if (parts.length == 3 && StringUtils.isNotEmpty(parts[2])) {
                 return true;
             }

--- a/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTBearerGrantHandler.java
+++ b/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTBearerGrantHandler.java
@@ -927,20 +927,7 @@ public class JWTBearerGrantHandler extends AbstractAuthorizationGrantHandler {
     protected X509Certificate resolveSignerCertificate(JWSHeader header,
                                                        IdentityProvider idp) throws IdentityOAuth2Exception {
 
-        X509Certificate x509Certificate = null;
-        try {
-            if (StringUtils.equals(IdentityApplicationConstants.RESIDENT_IDP_RESERVED_NAME,
-                    idp.getIdentityProviderName())) {
-                x509Certificate = (X509Certificate) OAuth2Util.getCertificate(tenantDomain);
-            } else {
-                x509Certificate =
-                        (X509Certificate) IdentityApplicationManagementUtil.decodeCertificate(idp.getCertificate());
-            }
-        } catch (CertificateException e) {
-            handleException("Error occurred while decoding public certificate of Identity Provider "
-                    + idp.getIdentityProviderName() + " for tenant domain " + tenantDomain);
-        }
-        return x509Certificate;
+        return OAuth2Util.resolverSignerCertificate(idp);
     }
 
     /**

--- a/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTBearerGrantHandler.java
+++ b/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTBearerGrantHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2022, WSO2 LLC. (http://www.wso2.com).
+ * Copyright (c) 2016-2025, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -31,7 +31,6 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.wso2.carbon.core.util.KeyStoreManager;
 import net.minidev.json.JSONArray;
 
 import java.security.cert.CertificateExpiredException;
@@ -49,7 +48,6 @@ import org.wso2.carbon.identity.application.common.model.Property;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationConstants;
 import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
 import org.wso2.carbon.identity.base.IdentityException;
-import org.wso2.carbon.identity.core.util.IdentityTenantUtil;
 import org.wso2.carbon.identity.core.util.IdentityUtil;
 import org.wso2.carbon.identity.oauth.common.OAuthConstants;
 import org.wso2.carbon.identity.oauth.config.OAuthServerConfiguration;
@@ -67,7 +65,6 @@ import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.carbon.idp.mgt.IdentityProviderManager;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
 
-import java.security.Key;
 import java.security.PublicKey;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -78,7 +75,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static org.wso2.carbon.identity.oauth2.grant.jwt.JWTConstants.DEFAULT_IAT_VALIDITY_PERIOD;
 import static org.wso2.carbon.identity.oauth2.grant.jwt.JWTConstants.PROP_ENABLE_IAT_VALIDATION;
@@ -99,7 +95,6 @@ public class JWTBearerGrantHandler extends AbstractAuthorizationGrantHandler {
             "Error while getting Resident Identity Provider of '%s' tenant.";
     private static final String ENFORCE_CERTIFICATE_VALIDITY
             = "JWTValidatorConfigs.EnforceCertificateExpiryTimeValidity";
-    private static Map<Integer, Key> privateKeys = new ConcurrentHashMap<>();
     private String[] registeredClaimNames = new String[]{"iss", "sub", "aud", "exp", "nbf", "iat", "jti"};
 
     private String tenantDomain;
@@ -248,7 +243,7 @@ public class JWTBearerGrantHandler extends AbstractAuthorizationGrantHandler {
             }
         } else {
             // The assertion is encrypted.
-            RSAPrivateKey rsaPrivateKey = getPrivateKey(tenantDomain);
+            RSAPrivateKey rsaPrivateKey = (RSAPrivateKey) OAuth2Util.getPrivateKey(tenantDomain);
             RSADecrypter decrypter = new RSADecrypter(rsaPrivateKey);
             try {
                 encryptedJWT.decrypt(decrypter);
@@ -934,8 +929,13 @@ public class JWTBearerGrantHandler extends AbstractAuthorizationGrantHandler {
 
         X509Certificate x509Certificate = null;
         try {
-            x509Certificate = (X509Certificate) IdentityApplicationManagementUtil
-                    .decodeCertificate(idp.getCertificate());
+            if (StringUtils.equals(IdentityApplicationConstants.RESIDENT_IDP_RESERVED_NAME,
+                    idp.getIdentityProviderName())) {
+                x509Certificate = (X509Certificate) OAuth2Util.getCertificate(tenantDomain);
+            } else {
+                x509Certificate =
+                        (X509Certificate) IdentityApplicationManagementUtil.decodeCertificate(idp.getCertificate());
+            }
         } catch (CertificateException e) {
             handleException("Error occurred while decoding public certificate of Identity Provider "
                     + idp.getIdentityProviderName() + " for tenant domain " + tenantDomain);
@@ -1004,46 +1004,6 @@ public class JWTBearerGrantHandler extends AbstractAuthorizationGrantHandler {
             }
             return null;
         }
-    }
-
-    private static RSAPrivateKey getPrivateKey(String tenantDomain) throws IdentityOAuth2Exception {
-
-        Key privateKey;
-        int tenantId = OAuth2Util.getTenantId(tenantDomain);
-        if (!(privateKeys.containsKey(tenantId))) {
-
-            try {
-                IdentityTenantUtil.initializeRegistry(tenantId, tenantDomain);
-            } catch (IdentityException e) {
-                throw new IdentityOAuth2Exception("Error occurred while loading registry for tenant " + tenantDomain,
-                        e);
-            }
-            // get tenant's key store manager
-            KeyStoreManager tenantKSM = KeyStoreManager.getInstance(tenantId);
-
-            if (!MultitenantConstants.SUPER_TENANT_DOMAIN_NAME.equals(tenantDomain)) {
-                // derive key store name
-                String ksName = tenantDomain.trim().replace(".", "-");
-                String jksName = ksName + ".jks";
-                // obtain private key
-                privateKey = tenantKSM.getPrivateKey(jksName, tenantDomain);
-
-            } else {
-                try {
-                    privateKey = tenantKSM.getDefaultPrivateKey();
-                } catch (Exception e) {
-                    //Intentionally catch Exception as an Exception is thrown from the above layer.
-                    throw new IdentityOAuth2Exception("Error while obtaining private key for super tenant", e);
-                }
-            }
-            //privateKey will not be null always
-            privateKeys.put(tenantId, privateKey);
-        } else {
-            //privateKey will not be null because containsKey() true says given key is exist and ConcurrentHashMap
-            // does not allow to store null values
-            privateKey = privateKeys.get(tenantId);
-        }
-        return (RSAPrivateKey) privateKey;
     }
 
     private boolean isEncryptedJWTSigned(String payload) {

--- a/pom.xml
+++ b/pom.xml
@@ -1,21 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
- ~ Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
- ~
- ~ WSO2 Inc. licenses this file to you under the Apache License,
- ~ Version 2.0 (the "License"); you may not use this file except
- ~ in compliance with the License.
- ~ You may obtain a copy of the License at
- ~
- ~    http://www.apache.org/licenses/LICENSE-2.0
- ~
- ~ Unless required by applicable law or agreed to in writing,
- ~ software distributed under the License is distributed on an
- ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- ~ KIND, either express or implied.  See the License for the
- ~ specific language governing permissions and limitations
- ~ under the License.
-	 -->
+  ~ Copyright (c) 2016-2025, WSO2 LLC. (http://www.wso2.com).
+  ~
+  ~ WSO2 LLC. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -369,7 +369,7 @@
     </distributionManagement>
     <properties>
         <carbon.identity.framework.version>7.7.140</carbon.identity.framework.version>
-        <carbon.identity.oauth.version>7.0.278-SNAPSHOT</carbon.identity.oauth.version>
+        <carbon.identity.oauth.version>7.0.286</carbon.identity.oauth.version>
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
         <org.apache.oltu.oauth2.client.version>0.31</org.apache.oltu.oauth2.client.version>
         <org.apache.oltu.oauth2.common.version>1.0.1</org.apache.oltu.oauth2.common.version>

--- a/pom.xml
+++ b/pom.xml
@@ -368,7 +368,7 @@
     </distributionManagement>
     <properties>
         <carbon.identity.framework.version>7.7.140</carbon.identity.framework.version>
-        <carbon.identity.oauth.version>7.0.226</carbon.identity.oauth.version>
+        <carbon.identity.oauth.version>7.0.278-SNAPSHOT</carbon.identity.oauth.version>
         <carbon.kernel.version>4.6.0</carbon.kernel.version>
         <org.apache.oltu.oauth2.client.version>0.31</org.apache.oltu.oauth2.client.version>
         <org.apache.oltu.oauth2.common.version>1.0.1</org.apache.oltu.oauth2.common.version>


### PR DESCRIPTION
### Changes
This PR introduces the necessary changes to support configuring a custom keystore for the OAuth protocol. It updates all relevant areas where keystores are used. If a custom keystore is not configured, the system will fall back to the default primary or tenanted keystore.

The main changes include:

- When the `KeyStoreManager` was previously used to resolve keystore keys, it is now replaced with the `IdentityKeyStoreResolver`, which dynamically selects the appropriate keystore—custom, primary, or tenanted.
- For scenarios where the IDP certificate is used, if the Identity Provider is the Resident IDP, the certificate will now be retrieved via `IdentityKeyStoreResolver`. For other IDPs, the certificate will still be accessed from the specific IDP data.
- Previously, there was an issue in the logic used to check whether the decrypted JWT was signed. The code incorrectly used `String[] parts = payload.split(".");`, which caused unexpected behavior because `.` is a special character in regular expressions. This has been fixed by escaping the dot character properly: `String[] parts = payload.split("\\.");`.

To configure a custom keystore for OAuth, use the following TOML configuration:

```toml
[[keystore.custom]]
file_name = "custom.p12"
password = "password"
type = "PKCS12"
alias = "myOrgCert"
key_password = "password"

[keystore.mapping.oauth]
keystore_file_name = "custom.p12"
use_in_all_tenants = true
```

### Related Issue
- https://github.com/wso2/product-is/issues/20564
