### PR TITLE
Support token exchange with resident IDP for local users

### DIFF
--- a/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTBearerGrantHandler.java
+++ b/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTBearerGrantHandler.java
@@ -88,7 +88,10 @@ import static org.wso2.carbon.identity.oauth2.grant.jwt.JWTConstants.PROP_REGIST
 public class JWTBearerGrantHandler extends AbstractAuthorizationGrantHandler {
 
     private static final String OAUTH_SPLIT_AUTHZ_USER_3_WAY = "OAuth.SplitAuthzUser3Way";
+    private static final String ENABLE_TOKEN_EXCHANGE_FOR_LOCAL_USERS_WITH_RESIDENT_IDP
+            = "OAuth.JWTGrant.EnableTokenExchangeForLocalUsersWithResidentIdP";
     private static final String DEFAULT_IDP_NAME = "default";
+    private static final String RESIDENT_IDP_NAME = "LOCAL";
     private static final Log log = LogFactory.getLog(JWTBearerGrantHandler.class);
     private static final String OIDC_IDP_ENTITY_ID = "IdPEntityId";
     private static final String ERROR_GET_RESIDENT_IDP =
@@ -474,7 +477,14 @@ public class JWTBearerGrantHandler extends AbstractAuthorizationGrantHandler {
                                      String authenticatedSubjectIdentifier) {
 
         AuthenticatedUser authenticatedUser;
-        if (Boolean.parseBoolean(IdentityUtil.getProperty(OAUTH_SPLIT_AUTHZ_USER_3_WAY))) {
+        if (Boolean.parseBoolean(IdentityUtil.getProperty(ENABLE_TOKEN_EXCHANGE_FOR_LOCAL_USERS_WITH_RESIDENT_IDP)) &&
+                RESIDENT_IDP_NAME.equals(identityProvider.getIdentityProviderName())) {
+            /*To determine the user store domain of the local user, it should be available in the subject identifier.
+            Hence, enable "Use user store domain in local subject identifier" config in the service provider which
+            generates the initial token.*/
+            authenticatedUser = OAuth2Util.getUserFromUserName(authenticatedSubjectIdentifier);
+            authenticatedUser.setAuthenticatedSubjectIdentifier(authenticatedSubjectIdentifier);
+        } else if (Boolean.parseBoolean(IdentityUtil.getProperty(OAUTH_SPLIT_AUTHZ_USER_3_WAY))) {
             authenticatedUser = OAuth2Util.getUserFromUserName(authenticatedSubjectIdentifier);
             authenticatedUser.setAuthenticatedSubjectIdentifier(authenticatedSubjectIdentifier);
         } else {

--- a/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTBearerGrantHandler.java
+++ b/component/grant-type/src/main/java/org/wso2/carbon/identity/oauth2/grant/jwt/JWTBearerGrantHandler.java
@@ -479,9 +479,11 @@ public class JWTBearerGrantHandler extends AbstractAuthorizationGrantHandler {
         AuthenticatedUser authenticatedUser;
         if (Boolean.parseBoolean(IdentityUtil.getProperty(ENABLE_TOKEN_EXCHANGE_FOR_LOCAL_USERS_WITH_RESIDENT_IDP)) &&
                 RESIDENT_IDP_NAME.equals(identityProvider.getIdentityProviderName())) {
-            /*To determine the user store domain of the local user, it should be available in the subject identifier.
+            /*
+            To determine the user store domain of the local user, it should be available in the subject identifier.
             Hence, enable "Use user store domain in local subject identifier" config in the service provider which
-            generates the initial token.*/
+            generates the initial token.
+            */
             authenticatedUser = OAuth2Util.getUserFromUserName(authenticatedSubjectIdentifier);
             authenticatedUser.setAuthenticatedSubjectIdentifier(authenticatedSubjectIdentifier);
         } else if (Boolean.parseBoolean(IdentityUtil.getProperty(OAUTH_SPLIT_AUTHZ_USER_3_WAY))) {


### PR DESCRIPTION
When token exchange flow initiated between 2 SPs in the same identity server, local users were being considered as federated users. Because of that, the authenticated user did not had the user store domain. When the authorization grant cache is cleared, we will be unable to fetch the user attributes from the user store. Also, with the information in the id token, we cannot determine whether it is a local user or not.

We are introducing a configuration to treat users as local users when resident IdP is resolved as the identity provider. No default value is added so it will always resolve as false if it is not defined in the deployment.toml

```
[oauth.grant_type.jwt]
enable_token_exchange_for_local_users_with_resident_idp=true
```

Related issue:
- https://github.com/wso2/product-is/issues/23827

Configuration PR:
- https://github.com/wso2/carbon-identity-framework/pull/6754